### PR TITLE
Configurable seed entropy

### DIFF
--- a/src/http/gateway_wallet.go
+++ b/src/http/gateway_wallet.go
@@ -166,7 +166,7 @@ type SeedReply struct {
 
 func newSeed() HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request, p *Path) error {
-		seed, e := wallet.NewSeed()
+		seed, e := wallet.NewSeed(wallet.SeedBitSize)
 		if e != nil {
 			return sendJson(w, http.StatusInternalServerError,
 				fmt.Sprintf("Error: %v", e))

--- a/src/iko/state.go
+++ b/src/iko/state.go
@@ -75,7 +75,7 @@ func (s *MemoryState) GetKittyUnspentTx(kittyID KittyID) (TxHash, bool) {
 	return kState.Transactions[len(kState.Transactions)-1], true
 }
 
-func (s MemoryState) GetAddressState(address cipher.Address) *AddressState {
+func (s *MemoryState) GetAddressState(address cipher.Address) *AddressState {
 	s.Lock()
 	defer s.Unlock()
 

--- a/src/wallet/seed.go
+++ b/src/wallet/seed.go
@@ -6,8 +6,8 @@ const (
 	SeedBitSize = 128
 )
 
-func NewSeed() (string, error) {
-	entropy, e := bip39.NewEntropy(SeedBitSize)
+func NewSeed(seedBitSize int) (string, error) {
+	entropy, e := bip39.NewEntropy(seedBitSize)
 	if e != nil {
 		return "", e
 	}

--- a/src/wallet/seed.go
+++ b/src/wallet/seed.go
@@ -1,9 +1,14 @@
 package wallet
 
-import "github.com/skycoin/skycoin/src/cipher/go-bip39"
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/skycoin/skycoin/src/cipher/go-bip39"
+)
 
 const (
-	SeedBitSize = 128
+	DefaultSeedBitSize = 128
 )
 
 func NewSeed(seedBitSize int) (string, error) {
@@ -16,4 +21,31 @@ func NewSeed(seedBitSize int) (string, error) {
 		return "", e
 	}
 	return mnemonic, nil
+}
+
+func ValidSeedBitSizes() []int {
+	return []int{DefaultSeedBitSize, 256}
+}
+
+// SeedBitSizeFromString determines the requested seed bit size from a
+// (possibly POSTed) string. A properly formatted integer string will return
+// the integer if it's one of our preconfigured bit sizes. An empty string
+// will return the default bit size. Any other strings return an error.
+func SeedBitSizeFromString(value string) (int, error) {
+	if value == "" {
+		return DefaultSeedBitSize, nil
+	}
+	requestedBitSize, e := strconv.Atoi(value)
+	if e != nil {
+		return 0, fmt.Errorf("Malformed integer string: %q", value)
+	}
+	for _, validSize := range ValidSeedBitSizes() {
+		if requestedBitSize == validSize {
+			return requestedBitSize, nil
+		}
+	}
+	return 0, fmt.Errorf("Unsupported seed bit size: %v (not one of %v)",
+		requestedBitSize,
+		ValidSeedBitSizes(),
+	)
 }

--- a/src/wallet/seed_test.go
+++ b/src/wallet/seed_test.go
@@ -1,0 +1,47 @@
+package wallet
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSeedBitSizeFromString_EmptyString(t *testing.T) {
+	val, err := SeedBitSizeFromString("")
+	require.Nil(t, err, "Should not return an error")
+	require.Equal(t, val, DefaultSeedBitSize,
+		"Should return the default seed bit size")
+}
+
+func TestSeedBitSizeFromString_Malformed(t *testing.T) {
+	_, err := SeedBitSizeFromString("don't think this is an int...")
+	require.NotNil(t, err, "Should return an error")
+}
+
+func TestSeedBitSizeFromString_Unsupported(t *testing.T) {
+	unsupportedSize := 5
+
+	// let's just confirm we're not using a supported bit size
+	for _, supportedSize := range ValidSeedBitSizes() {
+		if unsupportedSize == supportedSize {
+			require.NotEqual(t, supportedSize, unsupportedSize,
+				"We should be using an unsupported bit size, I must've messed up...")
+		}
+	}
+
+	unsupportedSizeString := fmt.Sprintf("%d", unsupportedSize)
+
+	_, err := SeedBitSizeFromString(unsupportedSizeString)
+	require.NotNil(t, err, "Should return an error")
+}
+
+func TestSeedBitSizeFromString_ValidIntString(t *testing.T) {
+	// let's test with a non-default value, which is index 1
+	supportedSize := ValidSeedBitSizes()[1]
+	supportedSizeStr := fmt.Sprintf("%d", supportedSize)
+
+	value, err := SeedBitSizeFromString(supportedSizeStr)
+	require.Nil(t, err, "Shouldn't return an error")
+	require.Equal(t, supportedSize, value, "Should return the int we gave it")
+}


### PR DESCRIPTION
Not done yet, but...: Fixes #30 

@evanlinjin I added a seedBitSize argument. Where do we want this value to be configurable? Is it a static value when the wallet is started up? Or is it an argument to the `/api/wallets/seed` API endpoint?